### PR TITLE
Provide a flat namespace combining env and system props

### DIFF
--- a/src/test/groovy/de/thomaskrille/dropwizard_template_config/AdditionalFreemarkerFeaturesSpec.groovy
+++ b/src/test/groovy/de/thomaskrille/dropwizard_template_config/AdditionalFreemarkerFeaturesSpec.groovy
@@ -23,12 +23,12 @@ class AdditionalFreemarkerFeaturesSpec extends Specification {
                 server:
                   applicationConnectors:
                     - type: http
-                      port: ${env.PORT!8080}
-                <#if env.ENABLE_SSL == 'true'>
+                      port: ${PORT!8080}
+                <#if ENABLE_SSL == 'true'>
                     - type: https
-                      port: ${env.SSL_PORT!8443}
-                      keyStorePath: ${env.SSL_KEYSTORE_PATH}
-                      keyStorePassword: ${env.SSL_KEYSTORE_PASS}
+                      port: ${SSL_PORT!8443}
+                      keyStorePath: ${SSL_KEYSTORE_PATH}
+                      keyStorePassword: ${SSL_KEYSTORE_PASS}
                 </#if>
                 '''
 
@@ -55,12 +55,12 @@ class AdditionalFreemarkerFeaturesSpec extends Specification {
                 server:
                   applicationConnectors:
                     - type: http
-                      port: ${env.PORT!8080}
-                <#if env.ENABLE_SSL == 'true'>
+                      port: ${PORT!8080}
+                <#if ENABLE_SSL == 'true'>
                     - type: https
-                      port: ${env.SSL_PORT!8443}
-                      keyStorePath: ${env.SSL_KEYSTORE_PATH}
-                      keyStorePassword: ${env.SSL_KEYSTORE_PASS}
+                      port: ${SSL_PORT!8443}
+                      keyStorePath: ${SSL_KEYSTORE_PATH}
+                      keyStorePassword: ${SSL_KEYSTORE_PASS}
                 </#if>
                 '''
 
@@ -81,12 +81,12 @@ class AdditionalFreemarkerFeaturesSpec extends Specification {
                 server:
                   applicationConnectors:
                     - type: http
-                      port: ${env.PORT!8080}
+                      port: ${PORT!8080}
                 <#-- Un-comment to enable HTTPS
                     - type: https
-                      port: ${env.SSL_PORT!8443}
-                      keyStorePath: ${env.SSL_KEYSTORE_PATH}
-                      keyStorePassword: ${env.SSL_KEYSTORE_PASS}
+                      port: ${SSL_PORT!8443}
+                      keyStorePath: ${SSL_KEYSTORE_PATH}
+                      keyStorePassword: ${SSL_KEYSTORE_PASS}
                 -->
                 '''
 
@@ -104,7 +104,7 @@ class AdditionalFreemarkerFeaturesSpec extends Specification {
         given:
         def config = '''
                 logging:
-                <#if env.PROFILE == 'production'>
+                <#if PROFILE == 'production'>
                   level: WARN
                   loggers:
                     com.example.my_app: INFO
@@ -113,7 +113,7 @@ class AdditionalFreemarkerFeaturesSpec extends Specification {
                     - type: syslog
                       host: localhost
                       facility: local0
-                <#elseif env.PROFILE == 'development'>
+                <#elseif PROFILE == 'development'>
                   level: INFO
                   loggers:
                     com.example.my_app: DEBUG
@@ -142,7 +142,7 @@ class AdditionalFreemarkerFeaturesSpec extends Specification {
         given:
         def config = '''
                 logging:
-                <#if env.PROFILE == 'production'>
+                <#if PROFILE == 'production'>
                   level: WARN
                   loggers:
                     com.example.my_app: INFO
@@ -151,7 +151,7 @@ class AdditionalFreemarkerFeaturesSpec extends Specification {
                     - type: syslog
                       host: localhost
                       facility: local0
-                <#elseif env.PROFILE == 'development'>
+                <#elseif PROFILE == 'development'>
                   level: INFO
                   loggers:
                     com.example.my_app: DEBUG

--- a/src/test/groovy/de/thomaskrille/dropwizard_template_config/EnvironmentVariablesSpec.groovy
+++ b/src/test/groovy/de/thomaskrille/dropwizard_template_config/EnvironmentVariablesSpec.groovy
@@ -24,7 +24,7 @@ class EnvironmentVariablesSpec extends Specification {
                           type: simple
                           connector:
                             type: http
-                            port: ${env.PORT}'''
+                            port: ${PORT}'''
 
         environmentProvider.put('PORT', '8080')
 
@@ -44,7 +44,7 @@ class EnvironmentVariablesSpec extends Specification {
                           type: simple
                           connector:
                             type: http
-                            port: ${env.PORT!8080}'''
+                            port: ${PORT!8080}'''
 
         when:
         InputStream parsedConfig = templateConfigurationSourceProvider.open(config)
@@ -62,7 +62,7 @@ class EnvironmentVariablesSpec extends Specification {
                           type: simple
                           connector:
                             type: http
-                            port: ${env.PORT}'''
+                            port: ${PORT}'''
 
         when:
         templateConfigurationSourceProvider.open(config)
@@ -72,5 +72,26 @@ class EnvironmentVariablesSpec extends Specification {
         def exceptionsCause = exception.cause
         exceptionsCause isA(freemarker.core.InvalidReferenceException)
     }
+
+    def 'can use env prefix'() throws Exception {
+        given:
+        def config = '''server:
+                          type: simple
+                          connector:
+                            type: http
+                            port: ${env.PORT}'''
+
+        environmentProvider.put('PORT', '8080')
+
+        when:
+        def parsedConfig = templateConfigurationSourceProvider.open(config)
+        def parsedConfigAsString = IOUtils.toString(parsedConfig)
+
+        then:
+        parsedConfigAsString containsString('server:')
+        parsedConfigAsString containsString('type: http')
+        parsedConfigAsString containsString('port: 8080')
+    }
+
 
 }

--- a/src/test/groovy/de/thomaskrille/dropwizard_template_config/OutputPathSpec.groovy
+++ b/src/test/groovy/de/thomaskrille/dropwizard_template_config/OutputPathSpec.groovy
@@ -26,7 +26,7 @@ class OutputPathSpec extends Specification {
                 server:
                   applicationConnectors:
                     - type: http
-                      port: ${env.PORT!8080}
+                      port: ${PORT!8080}
                 '''
 
         when:


### PR DESCRIPTION
Addresses #16 

I largely removed the use of `env.` and `sys.` from the README, assuming that the new non-namespaced style would generally be preferred. @tkrille, if you think that shouldn't be preferred usage, I can revert some of the README changes.