### PR TITLE
add TemplateConfigHashesProvider class

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ public void initialize(final Bootstrap<Configuration> bootstrap) {
         new TemplateConfigBundleConfiguration()
             .addCustomProvider(myCustomProvider1)
             .addCustomProvider(myCustomProvider2)
+            .addCustomHashesProvider(myCustommHashesProvider2)
+            .addCustomHashesProvider(myCustommHashesProvider2)
     ));
     ...
 }

--- a/src/main/java/de/thomaskrille/dropwizard_template_config/TemplateConfigBundleConfiguration.java
+++ b/src/main/java/de/thomaskrille/dropwizard_template_config/TemplateConfigBundleConfiguration.java
@@ -17,6 +17,7 @@ public class TemplateConfigBundleConfiguration {
     private String fileIncludePath;
     private String outputPath;
     private Set<TemplateConfigVariablesProvider> customProviders = new LinkedHashSet<>();
+    private Set<TemplateConfigHashesProvider> customHashesProviders = new LinkedHashSet<>();
 
     /**
      * Get the configured charset (Default: UTF-8)
@@ -71,6 +72,13 @@ public class TemplateConfigBundleConfiguration {
      */
     public Set<TemplateConfigVariablesProvider> customProviders() {
         return customProviders;
+    }
+
+    /**
+     * Get the set of custom hashes providers used to add hashes to the configuration template (Default: Empty Set)
+     */
+    public Set<TemplateConfigHashesProvider> customHashesProviders() {
+        return customHashesProviders;
     }
 
     /**
@@ -142,6 +150,14 @@ public class TemplateConfigBundleConfiguration {
      */
     public TemplateConfigBundleConfiguration addCustomProvider(TemplateConfigVariablesProvider customProvider) {
         this.customProviders.add(customProvider);
+        return this;
+    }
+
+    /**
+     * Add a custom hashes provider used to add your own hashes to the configuration template.
+     */
+    public TemplateConfigBundleConfiguration addCustomHashesProvider(TemplateConfigHashesProvider customHashesProvider) {
+        this.customHashesProviders.add(customHashesProvider);
         return this;
     }
 }

--- a/src/main/java/de/thomaskrille/dropwizard_template_config/TemplateConfigHashesProvider.java
+++ b/src/main/java/de/thomaskrille/dropwizard_template_config/TemplateConfigHashesProvider.java
@@ -1,0 +1,22 @@
+package de.thomaskrille.dropwizard_template_config;
+
+import java.util.Map;
+
+public interface TemplateConfigHashesProvider {
+
+    /**
+     * @return The namespace to use when accessing objects in the config template. Objects can either be accessed
+     * in the template with ${namespace.object} or without the namespace with ${object}. If you don't specify a
+     * namespace there may be collisions if multiple objects have the same name.  In this case the order of
+     * precedence is: environment variables, system variables, the variables from custom providers based on the
+     * order you add the providers with
+     * {@link TemplateConfigBundleConfiguration#addCustomHashesProvider(TemplateConfigHashesProvider)}.
+     */
+    String getNamespace();
+
+    /**
+     * @return A data model that the freemarker engine will use when parsing the config template.
+     */
+    Map<String, Object> getHashes();
+
+}

--- a/src/main/java/de/thomaskrille/dropwizard_template_config/TemplateConfigurationSourceProvider.java
+++ b/src/main/java/de/thomaskrille/dropwizard_template_config/TemplateConfigurationSourceProvider.java
@@ -92,10 +92,16 @@ public class TemplateConfigurationSourceProvider implements ConfigurationSourceP
         for (TemplateConfigVariablesProvider customProvider : configuration.customProviders()) {
             dataModel.putAll(customProvider.getVariables());
         }
+        for (TemplateConfigHashesProvider customHashesProvider : configuration.customHashesProviders()) {
+            dataModel.putAll(customHashesProvider.getHashes());
+        }
         dataModel.put("env", environmentProvider.getEnvironment());
         dataModel.put("sys", systemPropertiesProvider.getSystemProperties());
         for (TemplateConfigVariablesProvider customProvider : configuration.customProviders()) {
             dataModel.put(customProvider.getNamespace(), customProvider.getVariables());
+        }
+        for (TemplateConfigHashesProvider customHashesProvider : configuration.customHashesProviders()) {
+            dataModel.put(customHashesProvider.getNamespace(), customHashesProvider.getHashes());
         }
         return dataModel;
     }

--- a/src/test/groovy/de/thomaskrille/dropwizard_template_config/BundleCreationSpec.groovy
+++ b/src/test/groovy/de/thomaskrille/dropwizard_template_config/BundleCreationSpec.groovy
@@ -33,14 +33,20 @@ class BundleCreationSpec extends Specification {
         when:
         def providerA = new TestCustomProvider("providerA")
         def providerB = new TestCustomProvider("providerB")
+        def providerHashesA = new TestCustomHashesProvider("providerHashesA")
+        def providerHashesB = new TestCustomHashesProvider("providerHashesB")
         def bundle = new TemplateConfigBundle(
                 new TemplateConfigBundleConfiguration()
                         .addCustomProvider(providerB)
                         .addCustomProvider(providerA)
+                        .addCustomHashesProvider(providerHashesA)
+                        .addCustomHashesProvider(providerHashesB)
         )
 
         then:
         bundle.configuration.customProviders.containsAll([providerA, providerB])
         bundle.configuration.customProviders.size() == 2
+        bundle.configuration.customHashesProviders.containsAll([providerHashesA, providerHashesB])
+        bundle.configuration.customHashesProviders.size() == 2
     }
 }

--- a/src/test/groovy/de/thomaskrille/dropwizard_template_config/CustomProvidersSpec.groovy
+++ b/src/test/groovy/de/thomaskrille/dropwizard_template_config/CustomProvidersSpec.groovy
@@ -11,9 +11,13 @@ class CustomProvidersSpec extends Specification {
     def TestSystemPropertiesProvider systemPropertiesProvider = new TestSystemPropertiesProvider()
     def TestCustomProvider customProviderA = new TestCustomProvider("providerA")
     def TestCustomProvider customProviderB = new TestCustomProvider("providerB")
+    def TestCustomHashesProvider customHashesProviderA = new TestCustomHashesProvider("providerHashesA")
+    def TestCustomHashesProvider customHashesProviderB = new TestCustomHashesProvider("providerHashesB")
     def TemplateConfigBundleConfiguration templateConfigBundleConfiguration = new TemplateConfigBundleConfiguration()
             .addCustomProvider(customProviderA)
             .addCustomProvider(customProviderB)
+            .addCustomHashesProvider(customHashesProviderA)
+            .addCustomHashesProvider(customHashesProviderB)
 
     def TemplateConfigurationSourceProvider templateConfigurationSourceProvider =
             new TemplateConfigurationSourceProvider(new TestConfigSourceProvider(),
@@ -27,11 +31,13 @@ class CustomProvidersSpec extends Specification {
                           driverClass: org.postgresql.Driver
                           user: ${DB_USER}
                           password: ${DB_PASSWORD}
-                          url: jdbc:postgresql://${providerA.DB_HOST}:${providerB.DB_PORT}/my-app-db'''
+                          url: jdbc:${providerHashesB.DB_RDBMS}://${providerA.DB_HOST}:${providerB.DB_PORT}/${providerHashesA.DB_APP_NAME}'''
         customProviderA.put('DB_USER', 'user')
         customProviderB.put('DB_PASSWORD', 'password')
         customProviderA.put('DB_HOST', 'db-host')
         customProviderB.put('DB_PORT', '12345')
+        customHashesProviderA.put('DB_APP_NAME', 'my-app-db')
+        customHashesProviderB.put('DB_RDBMS', 'postgresql')
 
         when:
         InputStream parsedConfig = templateConfigurationSourceProvider.open(config)

--- a/src/test/java/de/thomaskrille/dropwizard_template_config/TestCustomHashesProvider.java
+++ b/src/test/java/de/thomaskrille/dropwizard_template_config/TestCustomHashesProvider.java
@@ -1,0 +1,27 @@
+package de.thomaskrille.dropwizard_template_config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestCustomHashesProvider implements TemplateConfigHashesProvider {
+    private final String namespace;
+    private final Map<String, Object> data = new HashMap<>();
+
+    public TestCustomHashesProvider(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public void put(String name, Object value) {
+        data.put(name, value);
+    }
+
+    @Override
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    @Override
+    public Map<String, Object> getHashes() {
+        return this.data;
+    }
+}


### PR DESCRIPTION
I often use dropwizard-template-config and for a project i need to add configuration objects. I couldn't do it via TemplateConfigVariablesProvider so i have created TemplateConfigHashesProvider class to make it possible which provide a Map<String, Object> for FreeMarker templates.